### PR TITLE
Add support for Flask shell context

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Configuration options
 =====================
 
 - ``KONCH_FLASK_IMPORTS``: Whether to automatically import top-level Flask functions and classes. Defaults to ``True``.
+- ``KONCH_FLASK_SHELL_CONTEXT``: Whether to automatically import Flask shell context, as registered by `shell_context_processor(f) <http://flask.pocoo.org/docs/0.12/api/#flask.Flask.shell_context_processor>`_. Defaults to ``True``.
 - ``KONCH_CONTEXT``: Dictionary of additional variables to include in the shell context.
 - ``KONCH_SHELL``: May be ``'ipy'``, ``'bpy'``, ``'ptpy'``, ``'ptipy'``, ``'py'``, or ``'auto'`` (default).
 - ``KONCH_BANNER``: Custom banner.

--- a/flask_konch/cli.py
+++ b/flask_konch/cli.py
@@ -8,6 +8,7 @@ import konch
 
 DEFAULTS = dict(
     KONCH_FLASK_IMPORTS=True,
+    KONCH_FLASK_SHELL_CONTEXT=True,
     KONCH_CONTEXT={},
     KONCH_SHELL='auto',
     KONCH_BANNER=None,
@@ -42,6 +43,11 @@ def cli():
         base_context.update(get_flask_imports())
 
     context = dict(base_context)
+
+    if options['KONCH_FLASK_SHELL_CONTEXT']:
+        flask_context = app.make_shell_context()
+        context.update(flask_context)
+
     context.update(options['KONCH_CONTEXT'])
 
     def context_formatter(ctx):
@@ -50,10 +56,19 @@ def cli():
             FLASK=click.style('Flask:', bold=True),
             base_context=formatted_base
         )
+        if options['KONCH_FLASK_SHELL_CONTEXT']:
+            variables = ', '.join(sorted(flask_context.keys()))
+            ret += '\n{ADDITIONAL}\n{variables}\n'.format(
+                ADDITIONAL=click.style(
+                    'Flask shell context (see shell_context_processor()):',
+                    bold=True
+                ),
+                variables=variables
+            )
         if options['KONCH_CONTEXT']:
             variables = ', '.join(sorted(options['KONCH_CONTEXT'].keys()))
             ret += '\n{ADDITIONAL}\n{variables}'.format(
-                ADDITIONAL=click.style('Additional variables:', bold=True),
+                ADDITIONAL=click.style('Additional variables (see KONCH_CONTEXT):', bold=True),
                 variables=variables
             )
         return ret

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,9 +52,18 @@ def test_no_flask_imports(run_command):
     assert 'Blueprint, Config, Flask,' not in result.output
 
 def test_additional_context(run_command):
-    result = run_command(config={'KONCH_CONTEXT': {'foo': 42, 'bar': 24}})
+    result = run_command(
+        config={
+            'KONCH_CONTEXT': {
+                'foo': 'foo-value',
+                'bar': 'bar-value'
+            }
+        },
+        input='bar'
+    )
     assert 'Additional variables (see KONCH_CONTEXT):' in result.output
     assert 'bar, foo' in result.output
+    assert '>>> \'bar-value\'' in result.output
 
 def test_flask_shell_context_processors(run_command):
     result = run_command(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,17 @@ def make_app():
         app = Flask('testapp')
         app.config['KONCH_SHELL'] = 'py'
         app.config.update(config)
+
+        # Register shell context
+        def shell_context_processor():
+            return {
+                'shellctx': 'shellctx-value',
+                'shellctx_overriden_by_konch_context': 'not-overridden'
+            }
+        app.shell_context_processor(shell_context_processor)
+
         return app
+
     return maker
 
 @pytest.fixture(scope='session')
@@ -43,8 +53,22 @@ def test_no_flask_imports(run_command):
 
 def test_additional_context(run_command):
     result = run_command(config={'KONCH_CONTEXT': {'foo': 42, 'bar': 24}})
-    assert 'Additional variables:' in result.output
+    assert 'Additional variables (see KONCH_CONTEXT):' in result.output
     assert 'bar, foo' in result.output
+
+def test_flask_shell_context_processors(run_command):
+    result = run_command(
+        config={
+            'KONCH_CONTEXT': {
+                'shellctx_overriden_by_konch_context': 'overridden-by-konch'
+            }
+        },
+        input='shellctx\nshellctx_overriden_by_konch_context'
+    )
+    # raise Exception(result.output)
+    assert 'Flask shell context (see shell_context_processor()):' in result.output
+    assert '>>> \'shellctx-value\'' in result.output
+    assert '>>> \'overridden-by-konch\'' in result.output
 
 def test_banner(run_command):
     result = run_command(config={'KONCH_BANNER': 'foobarbaz'})


### PR DESCRIPTION
`flask konch` should optionally use Flask's shell context (which is registered via `app.shell_context_processor(f)``). Flask shell context is available since Flask 0.11 (see http://flask.pocoo.org/docs/0.12/api/)

This allows it to use variables defined like here at [cookiecutter-flask](https://github.com/sloria/cookiecutter-flask/blob/master/%7B%7Bcookiecutter.app_name%7D%7D/%7B%7Bcookiecutter.app_name%7D%7D/app.py#L57) without the need for a separate (duplicated) `KONCH_CONTEXT`.

This PR implements this, including tests and an option `KONCH_FLASK_SHELL_CONTEXT` to turn it off (on by default).

