### PR TITLE
Upgrade to pytest 3.2 or any newer compatible version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 invoke==0.13.0
 
 # testing
-pytest==2.9.2
+pytest~=3.2
 tox>=1.5.0
 mock
 


### PR DESCRIPTION
....to ignore virtualenvs within working directory.

See new feature of [pytest 3.2.0](https://docs.pytest.org/en/latest/changelog.html#pytest-3-2-0-2017-07-30): "Collection ignores local virtualenvs by default; –collect-in-virtualenv overrides this behavior. (#2518)"  and pytest-dev/pytest#2518 

    its a regular mistake of beginners to just put a virtualenv into a working directory,
    and then be puzzled that its indeed there and ready to ruin their day

    we should detect it and warn about it instead

This just happened to me with the older pytest version :smile: 

Tests are still all OK after upgrading pytest.