### PR TITLE
Remove dependency on flask.globals._app_ctx_stack

### DIFF
--- a/flask_konch/cli.py
+++ b/flask_konch/cli.py
@@ -33,9 +33,9 @@ def get_flask_imports():
 @with_appcontext
 def cli():
     """An improved shell command, based on konch."""
-    from flask.globals import _app_ctx_stack
+    from flask import current_app
 
-    app = _app_ctx_stack.top.app
+    app = current_app
     options = {key: app.config.get(key, DEFAULTS[key]) for key in DEFAULTS.keys()}
     base_context = {"app": app}
     if options["KONCH_FLASK_IMPORTS"]:

--- a/flask_konch/cli.py
+++ b/flask_konch/cli.py
@@ -33,9 +33,7 @@ def get_flask_imports():
 @with_appcontext
 def cli():
     """An improved shell command, based on konch."""
-    from flask import current_app
-
-    app = current_app
+    app = flask.current_app
     options = {key: app.config.get(key, DEFAULTS[key]) for key in DEFAULTS.keys()}
     base_context = {"app": app}
     if options["KONCH_FLASK_IMPORTS"]:


### PR DESCRIPTION
The error was:
```
  File "/usr/local/lib/python3.12/site-packages/flask_konch/cli.py", line 39, in cli
    app = _app_ctx_stack.top.app
          ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'property' object has no attribute 'app'
```
The proposed change uses `flask.current_app` instead.